### PR TITLE
Update manifests/params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -85,6 +85,7 @@ class puppetdashboard::params {
   }
 
   $data_dir = $::operatingsystem ? {
+    /(?i:Debian|Ubuntu|Mint)/ => '/usr/share/puppet-dashboard/',
     default => '/var/puppet-dashboard',
   }
 


### PR DESCRIPTION
Debian installs dashboard to this location by default.

The default breaks when importing the database as the rake scripts are not in the default data_dir.

 exec { 'puppetdashboard_dbmigrate':
    cwd         => $puppetdashboard::data_dir,
    command     => 'rake RAILS_ENV=production db:migrate',
    require     => Mysql::Grant["puppetdashboard_grants_${fqdn}"],
    refreshonly => true,
    path        => '/usr/bin:/bin:/usr/sbin:/sbin',
