### PR TITLE
Fixed data_dir for RedHat based distros.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,8 +89,7 @@ class puppetdashboard::params {
   }
 
   $data_dir = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => '/usr/share/puppet-dashboard/',
-    default => '/var/puppet-dashboard',
+    default => '/usr/share/puppet-dashboard/',
   }
 
   $log_dir = $::operatingsystem ? {


### PR DESCRIPTION
Modified data_dir, set all distros to default value to
"/usr/share/puppet-dashboard/" as Deabian and RedHat based distros use
the same path.
